### PR TITLE
Add some tests, modify the auction demo test

### DIFF
--- a/nomos-tests/auction-demo.nom
+++ b/nomos-tests/auction-demo.nom
@@ -4,7 +4,9 @@ type auction = /\ <{*}| +{running : &{bid : int -> money -o |{*}> \/ auction,
                                                        lost : money * |{*}> \/ auction},
                                     cancel : |{*}> \/ auction}}
 
-proc transaction bid_client : (a : int), ($m : money), (#sa : auction) |{*}- ($d : 1) =
+type maybe_money = +{none: 1, some: money * 1}
+
+proc transaction bid_client : (a : int), ($m : money), (#sa : auction) |{*}- ($d : maybe_money) =
 {
   $la <- acquire #sa ;
   pay $la {*} ;
@@ -15,14 +17,13 @@ proc transaction bid_client : (a : int), ($m : money), (#sa : auction) |{*}- ($d
                get $la {*} ;
                #sa <- release $la ;
                work {*} ;
+               $d.none;
                close $d
   | ended => $la.cancel ;
              get $la {*} ;
              #sa <- release $la ;
-             $m.coins ;
-             pay $m {*} ;
-             wait $m ;
-             work {*} ;
+             $d.some;
+             send $d $m ;
              close $d
   )
 }
@@ -68,15 +69,21 @@ proc transaction main : . |{*}- ($d : 1) =
   let T = 100 ;
   let w = 0 ;
   let v = 0 ;
-  let n = 0 ;
+  let n = 3 ;
   $D <- dummy <- n ;
   $l <- empty_lot <- ;
-  #sa <- run <- T w v $D $l ;
+  #sa <- end_lot <- T w $D $l ;
   $M <- empty_wallet <- ;
   let A = 24 ;
   $c <- bid_client <- A $M #sa ;
-  wait $c ;
-  close $d
+  case $c (
+    none => wait $c;
+            close $d
+  | some => $m <- recv $c ;
+            wait $c ;
+            #w <- new_full <- $m ;
+            close $d
+  )
 }
 
 exec main
@@ -193,20 +200,6 @@ proc asset removebid : (r : int), ($bs : dictionary) |{*}- ($newbs : money * dic
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 type money = &{value : <{*}| int ^ money,
                coins : <{*}| lcoin}
 type lcoin = 1
@@ -221,6 +214,36 @@ proc asset empty_wallet : . |{*}- ($m : money) =
   $l <- emp <- ;
   let n = 0 ;
   $m <- wallet <- n $l
+}
+
+type one_time_wallet = /\ <{*}| +{full : &{take : money * |{*}> \/ one_time_wallet,
+                                           cancel : |{*}> \/ one_time_wallet},
+                                  empty : |{*}> \/ one_time_wallet}
+
+proc contract new_empty : . |{*}- (#w : one_time_wallet) =
+{
+  $wl <- accept #w ;
+  get $wl {*} ;
+  $wl.empty ;
+  pay $wl {*} ;
+  #w <- detach $wl ;
+  #w <- new_empty <-
+}
+
+proc contract new_full : ($m : money) |{*}- (#w : one_time_wallet) =
+{
+  $wl <- accept #w ;
+  get $wl {*} ;
+  $wl.full;
+  case $wl (
+    take => send $wl $m ;
+            pay $wl {*} ;
+            #w <- detach $wl ;
+            #w <- new_empty <-
+  | cancel => pay $wl {*} ;
+              $w <- detach $wl ;
+              #w <- new_full <- $m
+  )
 }
 
 proc asset wallet : (n : int), ($l : lcoin) |{*}- ($m : money) = 

--- a/nomos-tests/auction-demo.nom
+++ b/nomos-tests/auction-demo.nom
@@ -69,10 +69,10 @@ proc transaction main : . |{*}- ($d : 1) =
   let T = 100 ;
   let w = 0 ;
   let v = 0 ;
-  let n = 3 ;
+  let n = 0 ;
   $D <- dummy <- n ;
   $l <- empty_lot <- ;
-  #sa <- end_lot <- T w $D $l ;
+  #sa <- run <- T w v $D $l ;
   $M <- empty_wallet <- ;
   let A = 24 ;
   $c <- bid_client <- A $M #sa ;

--- a/nomos-tests/simple-wait.nom
+++ b/nomos-tests/simple-wait.nom
@@ -1,0 +1,13 @@
+proc asset emp : . |{*}- ($l : 1) = 
+{
+  close $l
+}
+
+proc transaction main : . |{*}- ($d : 1) =
+{
+  $a <- emp <- ;
+  wait $a ;
+  close $d
+}
+
+exec main

--- a/nomos-tests/wallet-demo.nom
+++ b/nomos-tests/wallet-demo.nom
@@ -1,0 +1,79 @@
+type money = &{value : <{*}| int ^ money,
+               coins : <{*}| lcoin}
+type lcoin = 1
+
+proc asset emp : . |{*}- ($l : lcoin) = 
+{
+  close $l
+}
+
+proc asset empty_wallet : . |{*}- ($m : money) = 
+{
+  $l <- emp <- ;
+  let n = 0 ;
+  $m <- wallet <- n $l
+}
+
+proc asset wallet : (n : int), ($l : lcoin) |{*}- ($m : money) = 
+{
+    case $m (
+      value => get $m {*};
+               send $m n;
+               $m <- wallet <- n $l 
+    | coins => get $m {*} ;
+               $m <- $l
+    )
+}
+
+type one_time_wallet = /\ <{*}| +{full : &{take : money * |{*}> \/ one_time_wallet,
+                                           cancel : |{*}> \/ one_time_wallet},
+                                  empty : |{*}> \/ one_time_wallet}
+
+proc contract new_empty : . |{*}- (#w : one_time_wallet) =
+{
+  $wle <- accept #w ;
+  get $wle {*} ;
+  $wle.empty ;
+  pay $wle {*} ;
+  #w <- detach $wle ;
+  #w <- new_empty <-
+}
+
+proc contract new_full : ($m : money) |{*}- (#w : one_time_wallet) =
+{
+  $wl <- accept #w ;
+  get $wl {*} ;
+  $wl.full;
+  case $wl (
+    take => send $wl $m ;
+            pay $wl {*} ;
+            #w <- detach $wl ;
+            #w <- new_empty <-
+  | cancel => pay $wl {*} ;
+              $w <- detach $wl ;
+              #w <- new_full <- $m
+  )
+}
+
+proc transaction main : . |{*}- ($d : 1) =
+{
+  $w <- empty_wallet <- ;
+  #ow <- new_full <- $w ;
+  $low <- acquire #ow ;
+  pay $low {*} ;
+  case $low (
+    full => $low.take ;
+            $m <- recv $low ;
+	    $m.coins ;
+	    pay $m {*} ;
+	    wait $m ;
+	    get $low {*} ;
+	    #ow <- release $low ;
+	    close $d
+  | empty => get $low {*} ;
+             #ow <- release $low ;
+	     close $d
+  )
+}
+
+exec main


### PR DESCRIPTION
Removes the wait on the coins hack in the auction demo, but creates a shared wallet if `bid_client` fails. Should have the same final state as the original auction-demo. You can see what I ran in to with `maybe_money` in that file.

Also added some simpler tests. Maybe it would be nice to be able to include other files so we don't have to keep copy-pasting code around.